### PR TITLE
add wally manifest

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "luau-roblox",
+  "tree": {
+    "$path": "src"
+  }
+}

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sythivorium/luau-roblox"
+description = "A Luau library to manipulate Roblox place and model files"
+version = "0.1.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+exclude = ["rbx-test-files", "scripts", "test"]
+include = ["src", "default.project.json", "LICENSE"]
+
+[dependencies]

--- a/wally.toml
+++ b/wally.toml
@@ -2,6 +2,7 @@
 name = "sythivorium/luau-roblox"
 description = "A Luau library to manipulate Roblox place and model files"
 version = "0.1.0"
+license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 exclude = ["rbx-test-files", "scripts", "test"]

--- a/wally.toml
+++ b/wally.toml
@@ -1,11 +1,11 @@
 [package]
-name = "sythivorium/luau-roblox"
+name = "scythe-technology/luau-roblox"
 description = "A Luau library to manipulate Roblox place and model files"
-version = "0.1.0"
+version = "0.0.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
-exclude = ["rbx-test-files", "scripts", "test"]
-include = ["src", "default.project.json", "LICENSE"]
+exclude = ["**"]
+include = ["src", "src/**", "default.project.json", "LICENSE", "wally.toml"]
 
 [dependencies]


### PR DESCRIPTION
This PR initialises a wally package, allowing others to easily install this as a dependency within their projects. Note that you may need to publish this package yourself. You will also need to start tracking the version of the project.

Feel free to add yourself as an author within `wally.toml`, albeit not necessary.